### PR TITLE
Separated CREATE TYPE geores definition on 'sql/createTypes.sql'

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,11 +3,11 @@
 
 source .env
 
-## Adding PostGIS extension support
-#psql -U ${DBROLE} -d ${DBNAME} -c "create extension postgis;"
-
 # Creating the necessary pgGeocoder Tables
 psql -U ${DBROLE} -d ${DBNAME} -f ./sql/createTables.sql
+
+# Creating the necessary pgGeocoder Types
+psql -U ${DBROLE} -d ${DBNAME} -f ./sql/createTypes.sql
 
 # Load geocoder function
 psql -U ${DBROLE} -d ${DBNAME} -f ./sql/pgGeocoder.sql

--- a/sql/createTypes.sql
+++ b/sql/createTypes.sql
@@ -1,0 +1,13 @@
+-- DROP TYPE geores CASCADE;
+
+CREATE TYPE geores AS (
+   code        integer,
+   x           double precision,
+   y           double precision,
+   address     character varying,
+   todofuken   character varying,
+   shikuchoson character varying,
+   ooaza       character varying,
+   chiban      character varying,  
+   go          character varying
+);

--- a/sql/pgGeocoder.sql
+++ b/sql/pgGeocoder.sql
@@ -30,19 +30,6 @@
 -- で請求してください(宛先は the Free Software Foundation, Inc., 59
 -- Temple Place, Suite 330, Boston, MA 02111-1307 USA)。
 
-DROP TYPE geores CASCADE;
-
-CREATE TYPE geores AS (
-   code        integer,
-   x           double precision,
-   y           double precision,
-   address     character varying,
-   todofuken   character varying,
-   shikuchoson character varying,
-   ooaza       character varying,
-   chiban      character varying,  
-   go          character varying
-);
 
 --
 --   Main Geocoder function.

--- a/sql/pgReverseGeocoder.sql
+++ b/sql/pgReverseGeocoder.sql
@@ -30,20 +30,6 @@
 -- で請求してください(宛先は the Free Software Foundation, Inc., 59
 -- Temple Place, Suite 330, Boston, MA 02111-1307 USA)。
 
--- DROP TYPE geores CASCADE;
-
-CREATE TYPE geores AS (
-   code        integer,
-   x           double precision,
-   y           double precision,
-   address     character varying,
-   todofuken   character varying,
-   shikuchoson character varying,
-   ooaza       character varying,
-   chiban      character varying,  
-   go          character varying
-);
-
 
 CREATE OR REPLACE FUNCTION mk_geores(
     record RECORD,

--- a/sql/pgReverseGeocoder.sql
+++ b/sql/pgReverseGeocoder.sql
@@ -84,7 +84,7 @@ BEGIN
     IF FOUND THEN
       RETURN mk_geores(record, 1);
     ELSE
-      SELECT INTO record todofuken, shikuchoson, ooaza, NULL as chiban,
+      SELECT INTO record todofuken, shikuchoson, ooaza, NULL::varchar as chiban,
         lon, lat,
         todofuken||shikuchoson||ooaza AS address,
         st_distance(point::geography,geog) AS dist 
@@ -105,7 +105,7 @@ BEGIN
   IF s_flag THEN
     SELECT INTO s_bdry geom FROM boundary_s WHERE st_intersects(point,geom);
     IF FOUND THEN
-      SELECT INTO record todofuken, shikuchoson, NULL as ooaza, NULL as chiban,
+      SELECT INTO record todofuken, shikuchoson, NULL::varchar as ooaza, NULL::varchar as chiban,
           lon, lat,
           todofuken||shikuchoson AS address, 0 AS dist
         FROM address_s AS a


### PR DESCRIPTION
Fixes #18.

Later, I will add equivalent PR to upstream, but I will fix this issue on this gtt-project forked side.

Changes proposed in this pull request:
- Separated CREATE TYPE geores definition on `sql/createTypes.sql`

@gtt-project/maintainer
